### PR TITLE
Improve build for Python FastAPI upstream template

### DIFF
--- a/template/vst-python-upstream-fastapi/.dockerignore
+++ b/template/vst-python-upstream-fastapi/.dockerignore
@@ -3,4 +3,5 @@
 
 ## Selectively include files and directories:
 !src/Pipfile
+!src/Pipfile.lock
 !src/function

--- a/template/vst-python-upstream-fastapi/Dockerfile
+++ b/template/vst-python-upstream-fastapi/Dockerfile
@@ -1,37 +1,42 @@
 ## Use of-watchdog:
 FROM openfaas/of-watchdog:0.7.2 as watchdog
 
-## Use Python 3.7:
-FROM python:3.7
+## Use Python 3.7-alpine:
+FROM python:3.7-alpine
 
 ## Copy watchdog and make it executable:
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
-## Upgrade pip and install pipenv
-RUN pip install --upgrade pip pipenv
-
-## Add non root user:
-RUN adduser --disabled-password --gecos "Application" appuser
-
-## Switch user:
-USER appuser
+## Perform essential installation and configuration:
+RUN apk update                                                                    && \
+    apk add --no-cache --virtual .build-deps git openssh-client gcc libc-dev make && \
+    pip install --no-cache-dir --upgrade pip pipenv                               && \
+    addgroup -S -g 1001 app                                                       && \
+    adduser -S -D -h /app -u 1001 -G app app
 
 ## Switch working directory:
-WORKDIR /home/appuser/
+WORKDIR /app
 
-## Copy pipenv stuff:
+## Copy Pipenv stuff:
 COPY src/Pipfile .
+COPY src/Pipfile.lock .
 
 ## Install:
-RUN pipenv install
+RUN pipenv install --system --deploy --clear
+
+## Clean-up:
+RUN apk del .build-deps
 
 ## Copy the program:
 COPY src/function function
 
+## Change user:
+USER app
+
 ## Set up of-watchdog:
 ENV cgi_headers="true"
-ENV fprocess="pipenv run gunicorn function.web:app -k uvicorn.workers.UvicornWorker --workers 1"
+ENV fprocess="gunicorn function.web:app -k uvicorn.workers.UvicornWorker --workers 1"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:8000"
 

--- a/template/vst-python-upstream-fastapi/src/.gitignore
+++ b/template/vst-python-upstream-fastapi/src/.gitignore
@@ -1,5 +1,4 @@
 .mypy_cache
 .pytest_cache
 .tox
-Pipfile.lock
 vs.code-workspace


### PR DESCRIPTION
We are now using `python:3.7-alpine`, relying on the Pipfile.lock.
